### PR TITLE
fix: fill area gradient for all week segments in global chart view

### DIFF
--- a/src/components/score-chart.tsx
+++ b/src/components/score-chart.tsx
@@ -86,16 +86,19 @@ export function ScoreChart({ year, eventCode }: Props) {
 		return { ...base, [weekKey(record.event.weekNumber)]: record.result.score };
 	});
 
-	// Bridge adjacent weeks so every segment has more than 2 data points for area fill.
-	// At each week transition, give the last point of the ending week a value for
-	// the next week's key (equal to the current score) so the next Area segment
-	// starts from where the previous one left off.
+	// Bridge adjacent weeks so every segment has enough defined points for area fill.
+	// At each week transition, copy the boundary score onto both sides:
+	// - the last point of the ending week gets the next week's key
+	// - the first point of the next week gets the ending week's key
+	// This keeps the fill continuous even when a week only has a single record.
 	if (!eventCode) {
 		for (let i = 0; i < chartData.length - 1; i++) {
 			const currentWeek = records[i].event.weekNumber;
 			const nextWeek = records[i + 1].event.weekNumber;
 			if (currentWeek !== nextWeek) {
-				chartData[i][weekKey(nextWeek)] = records[i].result.score;
+				const currentScore = records[i].result.score;
+				chartData[i][weekKey(nextWeek)] = currentScore;
+				chartData[i + 1][weekKey(currentWeek)] = currentScore;
 			}
 		}
 	}

--- a/src/components/score-chart.tsx
+++ b/src/components/score-chart.tsx
@@ -86,6 +86,20 @@ export function ScoreChart({ year, eventCode }: Props) {
 		return { ...base, [weekKey(record.event.weekNumber)]: record.result.score };
 	});
 
+	// Bridge adjacent weeks so every segment has ≥2 data points for area fill.
+	// At each week transition, give the last point of the ending week a value for
+	// the next week's key (equal to the current score) so the next Area segment
+	// starts from where the previous one left off.
+	if (!eventCode) {
+		for (let i = 0; i < chartData.length - 1; i++) {
+			const currentWeek = records[i].event.weekNumber;
+			const nextWeek = records[i + 1].event.weekNumber;
+			if (currentWeek !== nextWeek) {
+				chartData[i][weekKey(nextWeek)] = records[i].result.score;
+			}
+		}
+	}
+
 	const statusText = usedQuery.isPending
 		? 'Loading data...'
 		: usedQuery.isError

--- a/src/components/score-chart.tsx
+++ b/src/components/score-chart.tsx
@@ -86,7 +86,7 @@ export function ScoreChart({ year, eventCode }: Props) {
 		return { ...base, [weekKey(record.event.weekNumber)]: record.result.score };
 	});
 
-	// Bridge adjacent weeks so every segment has ≥2 data points for area fill.
+	// Bridge adjacent weeks so every segment has more than 2 data points for area fill.
 	// At each week transition, give the last point of the ending week a value for
 	// the next week's key (equal to the current score) so the next Area segment
 	// starts from where the previous one left off.


### PR DESCRIPTION
## Summary

- Week segments with only a single data point had no visible gradient fill because Recharts `Area` needs ≥2 points to render a filled area
- At each week boundary in the global view, bridge the transition by copying the current score into the next week's data key, giving every segment at least 2 data points so the gradient fill renders correctly

**Before:** Single-point weeks (e.g. Week 2, 3, 4) showed only a dot with no fill under the line
**After:** All week segments display the gradient fill consistently